### PR TITLE
Enhancement :: Show types of loaded soundpacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,6 +930,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2482,7 +2501,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -3048,6 +3067,7 @@ dependencies = [
  "notify-rust",
  "once_cell",
  "rand 0.9.1",
+ "rayon",
  "rdev",
  "rodio",
  "serde",
@@ -3305,7 +3325,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -4096,6 +4116,26 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "rdev"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,25 +930,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3067,7 +3048,6 @@ dependencies = [
  "notify-rust",
  "once_cell",
  "rand 0.9.1",
- "rayon",
  "rdev",
  "rodio",
  "serde",
@@ -4116,26 +4096,6 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
-
-[[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
 
 [[package]]
 name = "rdev"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ lucide-dioxus = { version = "2.1.0", features = ["all-icons"] }
 notify-rust = "4.11.3"
 once_cell = "1.21.3"
 rand = "0.9.0"
-rayon = "1.10.0"
 rdev = "0.5.3"
 rodio = "0.20.1"
 serde = "1.0.218"
@@ -38,8 +37,6 @@ version = "0.1.0"
 category = "Productivity"
 short_description = "MechvibesDX"
 long_description = "MechvibesDX is a modern, cross-platform soundboard for mechanical keyboards, inspired by the original Mechvibes project. It supports a wide range of keyboard sounds and is designed to be user-friendly and customizable."
-
-[profile]
 
 [profile.wasm-dev]
 inherits = "dev"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ lucide-dioxus = { version = "2.1.0", features = ["all-icons"] }
 notify-rust = "4.11.3"
 once_cell = "1.21.3"
 rand = "0.9.0"
+rayon = "1.10.0"
 rdev = "0.5.3"
 rodio = "0.20.1"
 serde = "1.0.218"

--- a/src/components/app_info.rs
+++ b/src/components/app_info.rs
@@ -23,9 +23,7 @@ pub fn AppInfoDisplay() -> Element {
     let soundpacks_dir_exists = paths::utils::soundpacks_dir_exists();
 
     // Count soundpacks
-    let soundpack_count = paths::utils::count_soundpacks();
-    let soundpack_mouse_count = paths::utils::count_mouse_soundpacks();
-    let soundpack_keyboard_count = paths::utils::count_keyboard_soundpacks();
+    let (soundpack_count_keyboard, soundpack_count_mouse) = paths::utils::count_soundpacks_by_type();
 
     // Get OS info
     let os = env::consts::OS;
@@ -79,7 +77,7 @@ pub fn AppInfoDisplay() -> Element {
           div {
             span { class: "text-base-content", "🎵" }
             span { class: "ml-2 text-base-content/70",
-              "Found {soundpack_count} soundpack(s) (Keyboard: {soundpack_keyboard_count}, Mouse: {soundpack_mouse_count})"
+              "Found {soundpack_count_keyboard + soundpack_count_mouse} soundpack(s) (Keyboard: {soundpack_count_keyboard}, Mouse: {soundpack_count_mouse})"
             }
           }
         }

--- a/src/components/app_info.rs
+++ b/src/components/app_info.rs
@@ -24,6 +24,8 @@ pub fn AppInfoDisplay() -> Element {
 
     // Count soundpacks
     let soundpack_count = paths::utils::count_soundpacks();
+    let soundpack_mouse_count = paths::utils::count_mouse_soundpacks();
+    let soundpack_keyboard_count = paths::utils::count_keyboard_soundpacks();
 
     // Get OS info
     let os = env::consts::OS;
@@ -77,7 +79,7 @@ pub fn AppInfoDisplay() -> Element {
           div {
             span { class: "text-base-content", "🎵" }
             span { class: "ml-2 text-base-content/70",
-              "Found {soundpack_count} soundpack(s)"
+              "Found {soundpack_count} soundpack(s) (Keyboard: {soundpack_keyboard_count}, Mouse: {soundpack_mouse_count})"
             }
           }
         }


### PR DESCRIPTION
This pull request introduces changes to improve functionality and user experience in the MechvibesDX application. The most notable updates include distinguishing between keyboard and mouse soundpacks, enhancing the `AppInfoDisplay` to show detailed soundpack counts, and refactoring the soundpack counting logic to support this differentiation.

### Enhancements to soundpack functionality:

* [`src/state/paths.rs`](diffhunk://#diff-d1d3c1e765095e0d03bcb3fd40b988b81bdb94f7704dccfb082ae245da3dde64L84-R132): Refactored the `count_soundpacks` function into `count_soundpacks_by_type`, which now differentiates between keyboard and mouse soundpacks by reading `config.json` files in soundpack directories. If no `config.json` is present, the soundpack is assumed to be for keyboards.

### Updates to user interface:

* [`src/components/app_info.rs`](diffhunk://#diff-15eee2b44b829fbffa565c8c987d42cef028ca3b4a813a8db9e5a9662f181d6bL26-R26): Updated the `AppInfoDisplay` function to display the total number of soundpacks found, along with a breakdown between keyboard and mouse soundpacks. [[1]](diffhunk://#diff-15eee2b44b829fbffa565c8c987d42cef028ca3b4a813a8db9e5a9662f181d6bL26-R26) [[2]](diffhunk://#diff-15eee2b44b829fbffa565c8c987d42cef028ca3b4a813a8db9e5a9662f181d6bL80-R80)

### Codebase cleanup:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L41-L42): Removed an unused `[profile]` section to simplify the configuration file.
* Removed rayon dependancy