### PR TITLE
Fix soundpacks url

### DIFF
--- a/src/components/ui/soundpack_manager.rs
+++ b/src/components/ui/soundpack_manager.rs
@@ -139,7 +139,7 @@ pub fn SoundpackManager(on_import_click: EventHandler<MouseEvent>) -> Element {
           div { class: "flex items-center gap-2",
             a {
               class: "btn btn-soft btn-sm",
-              href: "https://mechvibes.com/soun-dpacks?utm_source=mechvibes&utm_medium=app&utm_campaign=soundpack_manager",
+              href: "https://mechvibes.com/sound-packs?utm_source=mechvibes&utm_medium=app&utm_campaign=soundpack_manager",
               target: "_blank",
               "Browse soundpacks"
               ExternalLink { class: "w-4 h-4 ml-1" }


### PR DESCRIPTION
The current soundpacks url (`/soundpacks`) takes to a 404 page
I added the missing hyphen and made it (`sound-packs`)