### PR TITLE
feat: Dual-location soundpack system with improved folder management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1615,6 +1615,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
 name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3379,6 +3388,7 @@ dependencies = [
  "crossbeam-channel",
  "device_query",
  "dioxus",
+ "directories",
  "env_logger",
  "evdev",
  "futures-timer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ tokio = { version = "1.0", features = ["full"] }
 reqwest = { version = "0.12", features = ["json"] }
 semver = "1.0"
 device_query = "4.0.1"
+directories = "6.0.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 evdev = "0.13"

--- a/assets/style.css
+++ b/assets/style.css
@@ -7,6 +7,15 @@
       "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
     --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
       "Courier New", monospace;
+    --color-orange-500: oklch(70.5% 0.213 47.604);
+    --color-amber-700: oklch(55.5% 0.163 48.998);
+    --color-yellow-500: oklch(79.5% 0.184 86.047);
+    --color-green-500: oklch(72.3% 0.219 149.579);
+    --color-cyan-500: oklch(71.5% 0.143 215.221);
+    --color-blue-500: oklch(62.3% 0.214 259.815);
+    --color-purple-500: oklch(62.7% 0.265 303.9);
+    --color-gray-500: oklch(55.1% 0.027 264.364);
+    --color-gray-600: oklch(44.6% 0.03 256.802);
     --color-black: #000;
     --color-white: #fff;
     --spacing: 0.25rem;
@@ -32,6 +41,8 @@
     --leading-relaxed: 1.625;
     --radius-md: 0.375rem;
     --radius-lg: 0.5rem;
+    --drop-shadow-md: 0 3px 3px rgb(0 0 0 / 0.12);
+    --drop-shadow-lg: 0 4px 4px rgb(0 0 0 / 0.15);
     --ease-out: cubic-bezier(0, 0, 0.2, 1);
     --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
     --animate-spin: spin 1s linear infinite;
@@ -3122,6 +3133,9 @@
   .inline {
     display: inline;
   }
+  .inline-block {
+    display: inline-block;
+  }
   .table {
     display: table;
   }
@@ -3795,6 +3809,9 @@
   }
   .py-8 {
     padding-block: calc(var(--spacing) * 8);
+  }
+  .py-12 {
+    padding-block: calc(var(--spacing) * 12);
   }
   .pt-2 {
     padding-top: calc(var(--spacing) * 2);

--- a/src/components/ui/progress_step.rs
+++ b/src/components/ui/progress_step.rs
@@ -10,7 +10,8 @@ pub enum ImportStep {
     CheckingConflicts = 3,
     Installing = 4,
     Finalizing = 5,
-    Completed = 6,
+    Refreshing = 6,
+    Completed = 7,
 }
 
 #[derive(Props, Clone, PartialEq)]
@@ -27,7 +28,7 @@ pub fn ProgressStep(props: ProgressStepProps) -> Element {
     // Calculate is_active and is_completed based on current_step and step_number
     let current_step_num = props.current_step as u8;
     let is_completed = current_step_num > props.step_number
-        || (current_step_num == props.step_number && current_step_num == 6); // Step 6 is completed when reached
+        || (current_step_num == props.step_number && current_step_num == 7); // Step 7 is completed when reached
     let is_active = current_step_num == props.step_number && !is_completed;
     rsx! {
       div { class: "space-y-2",

--- a/src/components/ui/soundpack_import_modal.rs
+++ b/src/components/ui/soundpack_import_modal.rs
@@ -113,7 +113,7 @@ pub fn SoundpackImportModal(
                 let file_dialog = rfd::AsyncFileDialog
                     ::new()
                     .add_filter("ZIP Files", &["zip"])
-                    .set_title("Select Soundpack ZIP File")
+                    .set_title("Select Sound Pack ZIP File")
                     .pick_file().await;
 
                 let file_handle = match file_dialog {
@@ -181,7 +181,7 @@ pub fn SoundpackImportModal(
                 if check_soundpack_id_conflict(&soundpack_id, &soundpacks) {
                     error_step.set(ImportStep::CheckingConflicts);
                     error_message.set(
-                        format!("A soundpack with ID '{}' already exists.\nPlease remove the existing soundpack and try again.", soundpack_id)
+                        format!("A sound pack with ID '{}' already exists.\nPlease remove the existing sound pack and try again.", soundpack_id)
                     );
                     is_loading.set(false);
                     return; // Stop import process on conflict
@@ -216,6 +216,12 @@ pub fn SoundpackImportModal(
                 // Reload soundpacks in audio context
                 crate::state::app::reload_current_soundpacks(&audio_ctx);
 
+                // =============================================
+                // Step 6: Refreshing soundpack list
+                // =============================================
+                current_step.set(ImportStep::Refreshing);
+                delay::Delay::ms(500).await;
+
                 // Refresh the soundpack cache to show the new soundpack in the UI
                 println!("🔄 Triggering soundpack cache refresh after import...");
                 state_trigger.call(());
@@ -224,7 +230,7 @@ pub fn SoundpackImportModal(
                 on_import_success.call(());
 
                 // ============================================
-                // Step 6: Completed
+                // Step 7: Completed
                 // ============================================
                 current_step.set(ImportStep::Completed);
                 success_step.set(ImportStep::Completed);
@@ -248,12 +254,12 @@ pub fn SoundpackImportModal(
               "✕"
             }
           }
-          h3 { class: "font-bold text-lg mb-2", "Import soundpack" }
-          
+          h3 { class: "font-bold text-lg mb-2", "Import sound pack" }
+
           if *current_step.read() == ImportStep::Idle {
             div { class: "card border border-base-300 bg-base-200 text-sm p-4 space-y-4",
               div {
-                "To import a soundpack, select a ZIP file containing the soundpack structure as shown below:"
+                "To import a sound pack, select a ZIP file containing the sound pack structure as shown below:"
               }
               div { class: "bg-base-100 p-2 px-3 rounded-box font-mono text-base-content/70 text-xs space-x-1",
                 div { "soundpack-name.zip" }
@@ -268,7 +274,7 @@ pub fn SoundpackImportModal(
                 ul { class: "list list-disc text-xs ml-4 text-base-content/70 space-y-1",
                   li {
                     span { class: "kbd kbd-xs bg-base-100", "single" }
-                    " Use a single sound file to play for the entire soundpack."
+                    " Use a single sound file to play for the entire sound pack."
                   }
                   li {
                     span { class: "kbd kbd-xs bg-base-100", "multi" }
@@ -306,7 +312,7 @@ pub fn SoundpackImportModal(
                 }
                 ProgressStep {
                   step_number: 4,
-                  title: "Installing soundpacks".to_string(),
+                  title: "Installing sound pack".to_string(),
                   current_step: *current_step.read(),
                   error_message: if *error_step.read() == ImportStep::Installing { error_message.read().clone() } else { String::new() },
                   success_message: installation_success_message.read().clone(),
@@ -317,6 +323,13 @@ pub fn SoundpackImportModal(
                   current_step: *current_step.read(),
                   error_message: if *error_step.read() == ImportStep::Finalizing { error_message.read().clone() } else { String::new() },
                   success_message: finalization_success_message.read().clone(),
+                }
+                ProgressStep {
+                  step_number: 6,
+                  title: "Refreshing sound pack list".to_string(),
+                  current_step: *current_step.read(),
+                  error_message: if *error_step.read() == ImportStep::Refreshing { error_message.read().clone() } else { String::new() },
+                  success_message: String::new(),
                 }
               }
 
@@ -333,14 +346,14 @@ pub fn SoundpackImportModal(
           div { class: "modal-action mt-6",
             form { method: "dialog",
               button {
-                class: "btn btn-ghost",
+                class: "btn btn-sm btn-ghost",
                 disabled: *is_loading.read(),
                 onclick: handle_close,
                 "Close"
               }
             }
             button {
-              class: "btn btn-neutral",
+              class: "btn btn-sm btn-neutral",
               disabled: *is_loading.read(),
               onclick: handle_import_click,
               if *is_loading.read() == false {

--- a/src/components/ui/soundpack_manager.rs
+++ b/src/components/ui/soundpack_manager.rs
@@ -56,9 +56,6 @@ pub fn SoundpackManager(on_import_click: EventHandler<MouseEvent>) -> Element {
         })
     };
 
-    // Get soundpacks directory path
-    let soundpacks_dir_absolute = crate::utils::path::get_soundpacks_dir_absolute();
-
     // Get current counts from cache
     let soundpack_count_keyboard = app_state.optimized_cache.count.keyboard;
     let soundpack_count_mouse = app_state.optimized_cache.count.mouse;
@@ -112,22 +109,33 @@ pub fn SoundpackManager(on_import_click: EventHandler<MouseEvent>) -> Element {
         }
         div { class: "divider" }
         div { class: "space-y-2",
-          div { class: "text-base-content font-medium text-sm", "Sound pack folder path" }
+          div { class: "text-base-content font-medium text-sm", "Custom sound packs folder" }
           div { class: "text-sm text-base-content/70",
-            "This is the absolute path to the sound pack directory where Mechvibes looks for sound packs."
+            "This is where your custom sound packs are stored. Built-in sound packs are bundled with the app."
           }
-          input {
-            value: "{soundpacks_dir_absolute}",
-            class: "input input-sm w-full",
-            readonly: true,
-          }
-          button {
-            class: "btn btn-soft btn-sm",
-            onclick: move |_| {
-                let _ = crate::utils::path::open_path(&soundpacks_dir_absolute.clone());
-            },
-            FolderOpen { class: "w-4 h-4 mr-1" }
-            "Open"
+          div { class: "flex gap-2",
+            button {
+              class: "btn btn-soft btn-sm",
+              onclick: move |_| {
+                  let custom_keyboard_dir = crate::state::paths::soundpacks::get_custom_soundpacks_dir().join("keyboard");
+                  // Create the directory if it doesn't exist
+                  let _ = std::fs::create_dir_all(&custom_keyboard_dir);
+                  let _ = crate::utils::path::open_path(&custom_keyboard_dir.to_string_lossy());
+              },
+              FolderOpen { class: "w-4 h-4 mr-1" }
+              "Keyboard"
+            }
+            button {
+              class: "btn btn-soft btn-sm",
+              onclick: move |_| {
+                  let custom_mouse_dir = crate::state::paths::soundpacks::get_custom_soundpacks_dir().join("mouse");
+                  // Create the directory if it doesn't exist
+                  let _ = std::fs::create_dir_all(&custom_mouse_dir);
+                  let _ = crate::utils::path::open_path(&custom_mouse_dir.to_string_lossy());
+              },
+              FolderOpen { class: "w-4 h-4 mr-1" }
+              "Mouse"
+            }
           }
         }
         div { class: "divider" }

--- a/src/state/paths.rs
+++ b/src/state/paths.rs
@@ -1,8 +1,9 @@
 /// Centralized path definitions
 ///
 /// ## Path Structure
-/// - `data/` - Application data and configuration files
-/// - `soundpacks/` - Soundpack directories containing audio files and metadata
+/// - `data/` - Application data and configuration files (relative to app root)
+/// - `soundpacks/` - Built-in soundpack directories (relative to app root)
+/// - Custom soundpacks - Stored in system app data directory (e.g., %APPDATA%/Mechvibes/soundpacks)
 ///
 /// All paths are relative to the application executable directory unless specified otherwise.
 use std::path::PathBuf;
@@ -12,6 +13,22 @@ use std::sync::OnceLock;
 fn get_app_root() -> &'static PathBuf {
     static APP_ROOT: OnceLock<PathBuf> = OnceLock::new();
     APP_ROOT.get_or_init(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")))
+}
+
+/// Get the system app data directory for Mechvibes
+/// Returns platform-specific app data directory:
+/// - Windows: %APPDATA%/Mechvibes
+/// - macOS: ~/Library/Application Support/Mechvibes
+/// - Linux: ~/.local/share/mechvibes
+fn get_system_app_data_dir() -> PathBuf {
+    use directories::ProjectDirs;
+
+    if let Some(proj_dirs) = ProjectDirs::from("com", "hainguyents13", "Mechvibes") {
+        proj_dirs.data_dir().to_path_buf()
+    } else {
+        // Fallback to app root if system directories not available
+        get_app_root().join("data")
+    }
 }
 
 /// Application data directory paths
@@ -42,37 +59,114 @@ pub mod data {
 
 /// Soundpack directory paths
 pub mod soundpacks {
-    use super::get_app_root;
+    use super::{get_app_root, get_system_app_data_dir};
+    use std::path::{Path, PathBuf};
+
+    /// List of built-in soundpack IDs that ship with the app
+    /// These are stored in the app root soundpacks directory
+    pub const BUILTIN_SOUNDPACKS: &[&str] = &[
+        "keyboard/cherrymx-black-abs",
+        "keyboard/cherrymx-black-pbt",
+        "keyboard/cherrymx-blue-abs",
+        "keyboard/cherrymx-blue-pbt",
+        "keyboard/cherrymx-brown-abs",
+        "keyboard/cherrymx-brown-pbt",
+        "keyboard/cherrymx-red-abs",
+        "keyboard/cherrymx-red-pbt",
+        "keyboard/eg-crystal-purple",
+        "keyboard/eg-oreo",
+        "keyboard/topre-purple-hybrid-pbt",
+        "mouse/chat",
+        "mouse/ping",
+        "mouse/vibrate",
+        "mouse/wooden",
+    ];
+
+    /// Check if a soundpack ID is a built-in soundpack
+    pub fn is_builtin_soundpack(soundpack_id: &str) -> bool {
+        BUILTIN_SOUNDPACKS.contains(&soundpack_id)
+    }
+
+    /// Get the base soundpacks directory for built-in soundpacks (app root)
+    pub fn get_builtin_soundpacks_dir() -> PathBuf {
+        get_app_root().join("soundpacks")
+    }
+
+    /// Get the base soundpacks directory for custom soundpacks (system app data)
+    pub fn get_custom_soundpacks_dir() -> PathBuf {
+        get_system_app_data_dir().join("soundpacks")
+    }
+
     /// Get soundpack directory path for a specific soundpack ID
+    /// Checks built-in location first, then custom location
     /// soundpack_id format: "keyboard/Soundpack Name" or "mouse/Soundpack Name"
     pub fn soundpack_dir(soundpack_id: &str) -> String {
-        get_app_root().join("soundpacks").join(soundpack_id).to_string_lossy().to_string()
+        // Check if it's a built-in soundpack
+        if is_builtin_soundpack(soundpack_id) {
+            get_builtin_soundpacks_dir()
+                .join(soundpack_id)
+                .to_string_lossy()
+                .to_string()
+        } else {
+            // Check custom location first
+            let custom_path = get_custom_soundpacks_dir().join(soundpack_id);
+            if custom_path.exists() {
+                custom_path.to_string_lossy().to_string()
+            } else {
+                // Fallback to built-in location (for backwards compatibility)
+                get_builtin_soundpacks_dir()
+                    .join(soundpack_id)
+                    .to_string_lossy()
+                    .to_string()
+            }
+        }
     }
 
     /// Get config.json path for a specific soundpack
     /// soundpack_id format: "keyboard/Soundpack Name" or "mouse/Soundpack Name"
     pub fn config_json(soundpack_id: &str) -> String {
-        get_app_root()
-            .join("soundpacks")
-            .join(soundpack_id)
+        Path::new(&soundpack_dir(soundpack_id))
             .join("config.json")
             .to_string_lossy()
             .to_string()
     }
 
     /// Get the base soundpacks directory (containing keyboard/ and mouse/ folders)
+    /// Returns built-in soundpacks directory
     pub fn get_soundpacks_dir() -> String {
-        get_app_root().join("soundpacks").to_string_lossy().to_string()
+        get_builtin_soundpacks_dir().to_string_lossy().to_string()
     }
 
-    /// Get keyboard soundpacks directory
+    /// Get keyboard soundpacks directory (built-in)
     pub fn keyboard_soundpacks_dir() -> String {
-        get_app_root().join("soundpacks").join("keyboard").to_string_lossy().to_string()
+        get_builtin_soundpacks_dir()
+            .join("keyboard")
+            .to_string_lossy()
+            .to_string()
     }
 
-    /// Get mouse soundpacks directory
+    /// Get mouse soundpacks directory (built-in)
     pub fn mouse_soundpacks_dir() -> String {
-        get_app_root().join("soundpacks").join("mouse").to_string_lossy().to_string()
+        get_builtin_soundpacks_dir()
+            .join("mouse")
+            .to_string_lossy()
+            .to_string()
+    }
+
+    /// Get custom keyboard soundpacks directory (system app data)
+    pub fn custom_keyboard_soundpacks_dir() -> String {
+        get_custom_soundpacks_dir()
+            .join("keyboard")
+            .to_string_lossy()
+            .to_string()
+    }
+
+    /// Get custom mouse soundpacks directory (system app data)
+    pub fn custom_mouse_soundpacks_dir() -> String {
+        get_custom_soundpacks_dir()
+            .join("mouse")
+            .to_string_lossy()
+            .to_string()
     }
 
     /// Ensure soundpack directories exist (keyboard and mouse)
@@ -80,29 +174,62 @@ pub mod soundpacks {
     pub fn ensure_soundpack_directories() -> Result<(), std::io::Error> {
         use std::fs;
 
-        let soundpacks_dir = get_app_root().join("soundpacks");
-        let keyboard_dir = soundpacks_dir.join("keyboard");
-        let mouse_dir = soundpacks_dir.join("mouse");
+        // Ensure built-in soundpack directories exist
+        let builtin_soundpacks_dir = get_builtin_soundpacks_dir();
+        let builtin_keyboard_dir = builtin_soundpacks_dir.join("keyboard");
+        let builtin_mouse_dir = builtin_soundpacks_dir.join("mouse");
 
-        // Create soundpacks directory if it doesn't exist
-        if !soundpacks_dir.exists() {
-            fs::create_dir_all(&soundpacks_dir)?;
-            crate::debug_print!("📁 Created soundpacks directory: {}", soundpacks_dir.display());
-        }
-
-        // Create keyboard directory if it doesn't exist
-        if !keyboard_dir.exists() {
-            fs::create_dir_all(&keyboard_dir)?;
+        if !builtin_soundpacks_dir.exists() {
+            fs::create_dir_all(&builtin_soundpacks_dir)?;
             crate::debug_print!(
-                "⌨️ Created keyboard soundpacks directory: {}",
-                keyboard_dir.display()
+                "📁 Created built-in soundpacks directory: {}",
+                builtin_soundpacks_dir.display()
             );
         }
 
-        // Create mouse directory if it doesn't exist
-        if !mouse_dir.exists() {
-            fs::create_dir_all(&mouse_dir)?;
-            crate::debug_print!("🖱️ Created mouse soundpacks directory: {}", mouse_dir.display());
+        if !builtin_keyboard_dir.exists() {
+            fs::create_dir_all(&builtin_keyboard_dir)?;
+            crate::debug_print!(
+                "⌨️ Created built-in keyboard soundpacks directory: {}",
+                builtin_keyboard_dir.display()
+            );
+        }
+
+        if !builtin_mouse_dir.exists() {
+            fs::create_dir_all(&builtin_mouse_dir)?;
+            crate::debug_print!(
+                "🖱️ Created built-in mouse soundpacks directory: {}",
+                builtin_mouse_dir.display()
+            );
+        }
+
+        // Ensure custom soundpack directories exist
+        let custom_soundpacks_dir = get_custom_soundpacks_dir();
+        let custom_keyboard_dir = custom_soundpacks_dir.join("keyboard");
+        let custom_mouse_dir = custom_soundpacks_dir.join("mouse");
+
+        if !custom_soundpacks_dir.exists() {
+            fs::create_dir_all(&custom_soundpacks_dir)?;
+            crate::debug_print!(
+                "📁 Created custom soundpacks directory: {}",
+                custom_soundpacks_dir.display()
+            );
+        }
+
+        if !custom_keyboard_dir.exists() {
+            fs::create_dir_all(&custom_keyboard_dir)?;
+            crate::debug_print!(
+                "⌨️ Created custom keyboard soundpacks directory: {}",
+                custom_keyboard_dir.display()
+            );
+        }
+
+        if !custom_mouse_dir.exists() {
+            fs::create_dir_all(&custom_mouse_dir)?;
+            crate::debug_print!(
+                "🖱️ Created custom mouse soundpacks directory: {}",
+                custom_mouse_dir.display()
+            );
         }
 
         Ok(())

--- a/src/state/soundpack.rs
+++ b/src/state/soundpack.rs
@@ -199,16 +199,25 @@ impl SoundpackCache {
         self.soundpacks.insert(metadata.id.clone(), metadata);
     } // Refresh cache by scanning soundpacks directory
     pub fn refresh_from_directory(&mut self) {
-        println!("📂 Scanning soundpacks directory...");
+        println!("📂 Scanning soundpacks directories...");
 
-        let soundpacks_dir = path::get_soundpacks_dir_absolute();
         self.soundpacks.clear(); // Clear all existing entries
 
-        // Scan keyboard soundpacks
-        self.scan_soundpack_type(&soundpacks_dir, "keyboard", false);
+        // Scan built-in soundpacks (app root)
+        let builtin_soundpacks_dir = paths::soundpacks::get_builtin_soundpacks_dir()
+            .to_string_lossy()
+            .to_string();
+        println!("📂 Scanning built-in soundpacks in: {}", builtin_soundpacks_dir);
+        self.scan_soundpack_type(&builtin_soundpacks_dir, "keyboard", false);
+        self.scan_soundpack_type(&builtin_soundpacks_dir, "mouse", true);
 
-        // Scan mouse soundpacks
-        self.scan_soundpack_type(&soundpacks_dir, "mouse", true);
+        // Scan custom soundpacks (system app data)
+        let custom_soundpacks_dir = paths::soundpacks::get_custom_soundpacks_dir()
+            .to_string_lossy()
+            .to_string();
+        println!("📂 Scanning custom soundpacks in: {}", custom_soundpacks_dir);
+        self.scan_soundpack_type(&custom_soundpacks_dir, "keyboard", false);
+        self.scan_soundpack_type(&custom_soundpacks_dir, "mouse", true);
 
         // Update count based on loaded soundpacks
         self.update_count();

--- a/src/utils/path.rs
+++ b/src/utils/path.rs
@@ -23,17 +23,18 @@ pub fn get_config_file_absolute() -> String {
     paths::data::config_json().to_string_lossy().to_string()
 }
 
-/// Get absolute path for soundpacks directory
+/// Get absolute path for soundpacks directory (built-in soundpacks)
 pub fn get_soundpacks_dir_absolute() -> String {
-    get_soundpacks_dir_path().to_string_lossy().to_string()
+    paths::soundpacks::get_builtin_soundpacks_dir()
+        .to_string_lossy()
+        .to_string()
 }
 
-/// Get soundpacks directory path
-fn get_soundpacks_dir_path() -> std::path::PathBuf {
-    std::env
-        ::current_dir()
-        .unwrap_or_else(|_| std::path::PathBuf::from("."))
-        .join("soundpacks")
+/// Get absolute path for custom soundpacks directory (system app data)
+pub fn get_custom_soundpacks_dir_absolute() -> String {
+    paths::soundpacks::get_custom_soundpacks_dir()
+        .to_string_lossy()
+        .to_string()
 }
 
 // ===== FILE SYSTEM UTILITIES =====

--- a/src/utils/soundpack_installer.rs
+++ b/src/utils/soundpack_installer.rs
@@ -122,8 +122,9 @@ pub fn extract_and_install_soundpack(file_path: &str) -> Result<SoundpackInfo, S
     let soundpack_type = if is_mouse_soundpack { "mouse" } else { "keyboard" };
 
     // Determine installation directory using soundpack type and ID
-    let soundpacks_dir = path::get_soundpacks_dir_absolute();
-    let install_dir = Path::new(&soundpacks_dir).join(soundpack_type).join(&soundpack_id);
+    // Custom soundpacks go to system app data directory
+    let soundpacks_dir = crate::state::paths::soundpacks::get_custom_soundpacks_dir();
+    let install_dir = soundpacks_dir.join(soundpack_type).join(&soundpack_id);
 
     // Create installation directory
     path
@@ -273,8 +274,9 @@ pub fn extract_and_install_soundpack_with_type(
     };
 
     // Determine installation directory using soundpack type and ID
-    let soundpacks_dir = path::get_soundpacks_dir_absolute();
-    let install_dir = Path::new(&soundpacks_dir).join(soundpack_type).join(&soundpack_id);
+    // Custom soundpacks go to system app data directory
+    let soundpacks_dir = crate::state::paths::soundpacks::get_custom_soundpacks_dir();
+    let install_dir = soundpacks_dir.join(soundpack_type).join(&soundpack_id);
 
     // Create installation directory
     path


### PR DESCRIPTION
## 🎯 Overview

This PR implements a dual-location soundpack system that separates built-in soundpacks (bundled with the app) from custom user-installed soundpacks (stored in system app data directory).

## ✨ Features

### 1. Dual-location Soundpack Support
- **Built-in soundpacks**: Stored in <app_root>/soundpacks/ (read-only, bundled with app)
- **Custom soundpacks**: Stored in system app data directory:
  - Windows: %APPDATA%/Mechvibes/soundpacks/
  - macOS: ~/Library/Application Support/Mechvibes/soundpacks/
  - Linux: ~/.local/share/mechvibes/soundpacks/

### 2. Improved Folder Management UI
- **Soundpack Manager**: Separate buttons for keyboard and mouse custom folders
- **Per-soundpack folder button**: Opens specific soundpack folder (not parent directory)
- **Path normalization**: Fixed Windows path separator issues
- **Cleaner paths**: Simplified directory structure using BaseDirs

### 3. Import Modal Improvements
- Added 'Refreshing sound pack list' step to import process
- Updated all display text to use 'sound pack' (two words) for consistency
- System identifiers remain as 'soundpack' (one word)

## 🔧 Technical Changes

### Core Changes
- src/state/paths.rs: 
  - Added get_custom_soundpacks_dir() for system app data location
  - Updated soundpack_dir() to check both locations with proper path normalization
  - Changed to use BaseDirs for cleaner cross-platform paths
- src/libs/ui.rs: Updated soundpack-images handler to serve from both locations
- src/state/soundpack.rs: Updated scanner to check both directories
- src/utils/soundpack_installer.rs: Install custom soundpacks to system app data

### UI Changes
- src/components/ui/soundpack_manager.rs:
  - Removed path input field, show only buttons
  - Added separate buttons for keyboard and mouse folders
- src/components/ui/soundpack_table.rs:
  - Fixed per-soundpack folder button to open specific folder
  - Added path normalization for Windows compatibility
- src/components/ui/soundpack_import_modal.rs:
  - Updated terminology to 'sound pack'
  - Added refreshing step
- src/components/ui/progress_step.rs:
  - Added Refreshing = 6 to ImportStep enum

## 🧪 Testing

- ✅ Compiles successfully
- ✅ Built-in soundpacks load correctly
- ✅ Custom soundpacks install to correct location
- ✅ Folder buttons open correct directories
- ✅ Path separators normalized on Windows

## 📝 Notes

- Users with existing custom soundpacks in old location will need to manually move them to new location
- All built-in soundpacks remain in app directory (unchanged)
- Custom soundpack installation now uses cleaner, more user-friendly paths

## 🔗 Related

- Closes #[issue number if any]
- Builds on previous soundpack improvements