### PR TITLE
feat: add headless CLI mode with --soundpack flag addresses #71 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,8 +142,6 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cbdf310d77fd3aaee6ea2093db7011dc2d35d2eb3481e5607f1f8d942ed99df"
 dependencies = [
- "async-fs",
- "async-net",
  "enumflags2",
  "futures-channel",
  "futures-util",
@@ -169,103 +167,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "async-fs"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
-dependencies = [
- "async-lock",
- "blocking",
- "futures-lite",
-]
-
-[[package]]
-name = "async-io"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1237c0ae75a0f3765f58910ff9cdd0a12eeb39ab2f4c7de23262f337f0aacbb3"
-dependencies = [
- "async-lock",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix",
- "slab",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-net"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
-dependencies = [
- "async-io",
- "blocking",
- "futures-lite",
-]
-
-[[package]]
-name = "async-process"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde3f4e40e6021d7acffc90095cbd6dc54cb593903d1de5832f435eb274b85dc"
-dependencies = [
- "async-channel",
- "async-io",
- "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener",
- "futures-lite",
- "rustix",
- "tracing",
-]
-
-[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,30 +176,6 @@ dependencies = [
  "quote",
  "syn 2.0.103",
 ]
-
-[[package]]
-name = "async-signal"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7605a4e50d4b06df3898d5a70bf5fde51ed9059b0434b73105193bc27acce0d"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -440,19 +317,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "340d2f0bdb2a43c1d3cd40513185b2bd7def0aa1052f956455114bc98f82dcf2"
 dependencies = [
  "objc2",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
-dependencies = [
- "async-channel",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
 ]
 
 [[package]]
@@ -2547,12 +2411,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4145,17 +4003,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "piper"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4172,21 +4019,6 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
-]
-
-[[package]]
-name = "polling"
-version = "3.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b53a684391ad002dd6a596ceb6c74fd004fdce75f4be2e3f615068abbea5fd50"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix",
- "tracing",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6982,14 +6814,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3a7c7cee313d044fca3f48fa782cb750c79e4ca76ba7bc7718cd4024cdf6f68"
 dependencies = [
  "async-broadcast",
- "async-executor",
- "async-io",
- "async-lock",
- "async-process",
  "async-recursion",
- "async-task",
  "async-trait",
- "blocking",
  "enumflags2",
  "event-listener",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ once_cell = "1.21.3"
 open = "5.3.0"
 rand = "0.9.0"
 rdev = { version = "0.5.3", features = ["unstable_grab"] }
-rfd = "0.15"
+rfd = { version = "0.15", default-features = false, features = ["xdg-portal", "tokio"] }
 rodio = "0.20.1"
 cpal = "0.15"
 hound = "3.5"

--- a/src/libs/cli.rs
+++ b/src/libs/cli.rs
@@ -1,0 +1,109 @@
+use crate::libs::audio::AudioContext;
+use crate::libs::input_listener::start_unified_input_listener;
+use crate::libs::input_manager::{
+    init_input_channels, init_window_focus_state_with_value, get_window_focus_state, get_input_channels,
+};
+use crate::utils::constants::APP_NAME;
+use std::sync::mpsc;
+use std::time::Duration;
+
+#[cfg(target_os = "linux")]
+use crate::libs::evdev_input_listener::start_evdev_keyboard_listener;
+#[cfg(target_os = "linux")]
+use std::sync::{Arc, Mutex};
+
+pub fn run_cli_mode(soundpack_name: &str) {
+    println!("🔊 Starting {} in CLI mode with soundpack: {}", APP_NAME, soundpack_name);
+
+    // Initialize audio context (loads soundpack, creates audio stream)
+    let audio_ctx = AudioContext::new();
+
+    // Create input event channels
+    let (keyboard_tx, keyboard_rx) = mpsc::channel::<String>();
+    let (mouse_tx, mouse_rx) = mpsc::channel::<String>();
+    let (hotkey_tx, hotkey_rx) = mpsc::channel::<String>();
+
+    let keyboard_tx_clone = keyboard_tx.clone();
+    let mouse_tx_clone = mouse_tx.clone();
+    let hotkey_tx_clone = hotkey_tx.clone();
+
+    init_input_channels(
+        keyboard_rx, mouse_rx, hotkey_rx,
+        keyboard_tx_clone, mouse_tx_clone, hotkey_tx_clone,
+    );
+
+    // CLI mode is always "focused"
+    init_window_focus_state_with_value(true);
+
+    // Start input listeners
+    #[cfg(target_os = "linux")]
+    {
+        let display_server = std::env::var("XDG_SESSION_TYPE").unwrap_or_else(|_| "x11".to_string());
+        if display_server == "wayland" {
+            let focus_state = get_window_focus_state();
+            start_evdev_keyboard_listener(keyboard_tx.clone(), hotkey_tx.clone(), focus_state);
+            let always_focused = Arc::new(Mutex::new(true));
+            start_unified_input_listener(keyboard_tx, mouse_tx, hotkey_tx, Some(always_focused));
+        } else {
+            let focus_state = get_window_focus_state();
+            start_unified_input_listener(keyboard_tx.clone(), mouse_tx, hotkey_tx, Some(focus_state.clone()));
+            crate::libs::focused_input_listener::start_focused_keyboard_listener(keyboard_tx, focus_state);
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let focus_state = get_window_focus_state();
+        start_unified_input_listener(keyboard_tx.clone(), mouse_tx, hotkey_tx, Some(focus_state.clone()));
+        crate::libs::focused_input_listener::start_focused_keyboard_listener(keyboard_tx, focus_state);
+    }
+
+    // Get channel receivers from global state
+    let channels = get_input_channels();
+
+    println!("✅ Listening for keyboard/mouse events... Press Ctrl+C to quit.");
+
+    // Sound toggle state
+    let mut sound_enabled = true;
+
+    // Main event loop
+    loop {
+        // Check for hotkey (toggle sound)
+        if let Ok(msg) = channels.hotkey_rx.lock().unwrap().try_recv() {
+            if msg == "TOGGLE_SOUND" {
+                sound_enabled = !sound_enabled;
+                println!("🔊 Sound {}", if sound_enabled { "enabled" } else { "disabled" });
+            }
+        }
+
+        // Process keyboard events
+        if let Ok(keycode) = channels.keyboard_rx.lock().unwrap().try_recv() {
+            if keycode.starts_with("UP:") {
+                let key = &keycode[3..];
+                if sound_enabled {
+                    audio_ctx.play_key_event_sound(key, false);
+                }
+            } else if !keycode.is_empty() {
+                if sound_enabled {
+                    audio_ctx.play_key_event_sound(&keycode, true);
+                }
+            }
+        }
+
+        // Process mouse events
+        if let Ok(button_code) = channels.mouse_rx.lock().unwrap().try_recv() {
+            if button_code.starts_with("UP:") {
+                let button = &button_code[3..];
+                if sound_enabled {
+                    audio_ctx.play_mouse_event_sound(button, false);
+                }
+            } else if !button_code.is_empty() {
+                if sound_enabled {
+                    audio_ctx.play_mouse_event_sound(&button_code, true);
+                }
+            }
+        }
+
+        std::thread::sleep(Duration::from_millis(1));
+    }
+}

--- a/src/libs/evdev_input_listener.rs
+++ b/src/libs/evdev_input_listener.rs
@@ -12,7 +12,8 @@ pub fn start_evdev_keyboard_listener(
     _is_focused: Arc<Mutex<bool>>,
 ) {
     thread::spawn(move || {
-        use evdev::{Device, EventType, Key};
+        use evdev::{Device, EventType, KeyCode};
+        type Key = KeyCode;
 
         println!("🔍 [evdev] Starting Linux keyboard listener (Wayland/X11 compatible)");
 
@@ -23,26 +24,17 @@ pub fn start_evdev_keyboard_listener(
         // Find all keyboard devices
         let mut keyboards = Vec::new();
         
-        match evdev::enumerate().map(|t| t.collect::<Vec<_>>()) {
-            Ok(devices) => {
-                for (path, mut device) in devices {
-                    // Check if device has keyboard capabilities
-                    if device.supported_keys().is_some() {
-                        println!("🔍 [evdev] Found keyboard device: {:?} - {}", path.display(), device.name().unwrap_or("Unknown"));
+        for (path, mut device) in evdev::enumerate() {
+            // Check if device has keyboard capabilities
+            if device.supported_keys().is_some() {
+                println!("🔍 [evdev] Found keyboard device: {:?} - {}", path.display(), device.name().unwrap_or("Unknown"));
 
-                        // Set device to non-blocking mode to prevent blocking on idle devices
-                        if let Err(e) = device.set_nonblocking(true) {
-                            eprintln!("⚠️ [evdev] Failed to set non-blocking mode for {:?}: {}", path.display(), e);
-                        }
-
-                        keyboards.push(device);
-                    }
+                // Set device to non-blocking mode to prevent blocking on idle devices
+                if let Err(e) = device.set_nonblocking(true) {
+                    eprintln!("⚠️ [evdev] Failed to set non-blocking mode for {:?}: {}", path.display(), e);
                 }
-            }
-            Err(e) => {
-                eprintln!("❌ [evdev] Failed to enumerate devices: {}", e);
-                eprintln!("💡 [evdev] Make sure you're in the 'input' group: sudo usermod -a -G input $USER");
-                return;
+
+                keyboards.push(device);
             }
         }
         
@@ -64,8 +56,8 @@ pub fn start_evdev_keyboard_listener(
                             if event.event_type() == EventType::KEY {
                                 let key_value = event.value();
 
-                                if let Ok(key) = Key::new(event.code()) {
-                                    let key_code = map_evdev_keycode(key);
+                                let key = Key::new(event.code());
+                                let key_code = map_evdev_keycode(key);
                                     if !key_code.is_empty() {
                                         // Handle key press (value == 1)
                                         if key_value == 1 {
@@ -109,7 +101,6 @@ pub fn start_evdev_keyboard_listener(
                                         }
                                         // Ignore key repeat (value == 2)
                                     }
-                                }
                             }
                         }
                     }
@@ -129,8 +120,8 @@ pub fn start_evdev_keyboard_listener(
 }
 
 #[cfg(target_os = "linux")]
-fn map_evdev_keycode(key: evdev::Key) -> &'static str {
-    use evdev::Key::*;
+fn map_evdev_keycode(key: evdev::KeyCode) -> &'static str {
+    type Key = evdev::KeyCode;
     
     match key {
         // Letters

--- a/src/libs/mod.rs
+++ b/src/libs/mod.rs
@@ -1,4 +1,5 @@
 pub mod audio;
+pub mod cli;
 pub mod device_manager;
 pub mod focused_input_listener;
 pub mod input_device_manager;

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,11 +84,34 @@ fn main() {
     let args: Vec<String> = std::env::args().collect();
     debug_print!("🔍 Command line args: {:?}", args);
 
+    // Check for --soundpack flag
+    let cli_soundpack = args.windows(2).find(|w| w[0] == "--soundpack").map(|w| {
+        let name = w[1].clone();
+        // Auto-prepend keyboard/ if no prefix given
+        if !name.starts_with("keyboard/") && !name.starts_with("mouse/") {
+            format!("keyboard/{}", name)
+        } else {
+            name
+        }
+    });
+    if let Some(ref sp) = cli_soundpack {
+        debug_print!("🎯 CLI soundpack override: {}", sp);
+    }
+
     // Check if we should start minimized (from auto-startup)
     let should_start_minimized =
         args.contains(&"--minimized".to_string()) ||
         (state::config::AppConfig::load().auto_start &&
             state::config::AppConfig::load().start_minimized);
+
+    // Apply CLI soundpack override and run in headless mode
+    if let Some(ref soundpack_name) = cli_soundpack {
+        let mut config = state::config::AppConfig::load();
+        config.keyboard_soundpack = soundpack_name.clone();
+        let _ = config.save();
+        libs::cli::run_cli_mode(soundpack_name);
+        return;
+    }
 
     // Register protocol on first run
     // if let Err(e) = protocol::register_protocol() {

--- a/src/state/paths.rs
+++ b/src/state/paths.rs
@@ -20,7 +20,9 @@ fn get_app_root() -> &'static PathBuf {
             if let Some(exe_dir) = exe_path.parent() {
                 // Check if running in dev mode (dx serve creates target/dx/... path)
                 let exe_path_str = exe_path.to_string_lossy();
-                if exe_path_str.contains("target\\dx\\") || exe_path_str.contains("target/dx/") {
+                if exe_path_str.contains("target\\dx\\") || exe_path_str.contains("target/dx/") ||
+                   exe_path_str.contains("target\\debug\\") || exe_path_str.contains("target/debug/") ||
+                   exe_path_str.contains("target\\release\\") || exe_path_str.contains("target/release/") {
                     // In dev mode, use current working directory (project root)
                     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
                     println!("📂 App root (dev mode - from cwd): {}", cwd.display());


### PR DESCRIPTION
Add headless CLI mode — no GUI, just keyboard→sound.
```bash
mechvibes --soundpack cherrymx-black-abs
mechvibes --soundpack mouse/chat
Ctrl+Alt+M toggles sound. Ctrl+C quits.
- src/libs/cli.rs — headless event loop
- src/main.rs — --soundpack flag parsing
- src/libs/evdev_input_listener.rs — evdev v0.13 API fix
- src/state/paths.rs — dev mode path detection
- Cargo.toml — rfd/ashpd compile fix
Tested: soundpack loads, no GUI opens, toggle works, Linux Wayland+X11 builds.